### PR TITLE
Add Skills Section and Word Clouds

### DIFF
--- a/config-empty.toml
+++ b/config-empty.toml
@@ -85,5 +85,10 @@ theme = "hugo-lodi-theme"
     title = "Projects"
     subtitle = "Open Source and Personal Projects"
 
+[params.skills]
+    enable = true
+    title = "Skills"
+    subtitle = ""
+
 [params.footer]
     enable = true

--- a/config.toml
+++ b/config.toml
@@ -41,5 +41,10 @@ disableKinds = ["taxonomy", "term"]
     title = "Projects"
     subtitle = "Open Source and Personal Projects"
 
+[params.skills]
+    enable = true
+    title = "Skills"
+    subtitle = ""
+
 [params.footer]
     enable = true

--- a/data/skills/frameworks.yml
+++ b/data/skills/frameworks.yml
@@ -2,16 +2,16 @@ weight: 2
 title: "Platforms and Frameworks"
 items:
   - name: ".NET"
-    weight: 5
+    weight: 9
   - name: "Node.js"
-    weight: 3
+    weight: 7
   - name: "docker"
     weight: 4
   - name: "AWS"
-    weight: 4
+    weight: 7
   - name: "Azure"
-    weight: 3
+    weight: 5
   - name: "Linux"
-    weight: 2
+    weight: 1
   - name: "Windows"
     weight: 2

--- a/data/skills/frameworks.yml
+++ b/data/skills/frameworks.yml
@@ -1,0 +1,11 @@
+weight: 2
+title: "Platforms and Frameworks"
+items:
+  - name: ".NET"
+  - name: "Node.js"
+  - name: "win32"
+  - name: "docker"
+  - name: "AWS"
+  - name: "Azure"
+  - name: "Linux"
+  - name: "Windows"

--- a/data/skills/frameworks.yml
+++ b/data/skills/frameworks.yml
@@ -1,16 +1,16 @@
 weight: 2
-title: "Platforms and Frameworks"
+title: "Platforms"
 items:
   - name: ".NET"
     weight: 9
-  - name: "Node.js"
-    weight: 7
   - name: "docker"
     weight: 4
   - name: "AWS"
     weight: 7
   - name: "Azure"
     weight: 5
+  - name: "Node.js"
+    weight: 7
   - name: "Linux"
     weight: 1
   - name: "Windows"

--- a/data/skills/frameworks.yml
+++ b/data/skills/frameworks.yml
@@ -2,10 +2,16 @@ weight: 2
 title: "Platforms and Frameworks"
 items:
   - name: ".NET"
+    weight: 5
   - name: "Node.js"
-  - name: "win32"
+    weight: 3
   - name: "docker"
+    weight: 4
   - name: "AWS"
+    weight: 4
   - name: "Azure"
+    weight: 3
   - name: "Linux"
+    weight: 2
   - name: "Windows"
+    weight: 2

--- a/data/skills/languages.yml
+++ b/data/skills/languages.yml
@@ -2,11 +2,20 @@ weight: 1
 title: "Languages"
 items:
   - name: "C#"
+    weight: 5
   - name: "C++"
+    weight: 4
   - name: "TypeScript"
+    weight: 4
   - name: "Python"
+    weight: 2
   - name: "SQL"
+    weight: 3
   - name: "Ruby"
+    weight: 1
   - name: "Bash"
+    weight: 2
   - name: "Batch"
+    weight: 2
   - name: "PowerShell"
+    weight: 1

--- a/data/skills/languages.yml
+++ b/data/skills/languages.yml
@@ -2,20 +2,20 @@ weight: 1
 title: "Languages"
 items:
   - name: "C#"
-    weight: 5
+    weight: 9
   - name: "C++"
-    weight: 4
+    weight: 6
   - name: "TypeScript"
-    weight: 4
+    weight: 8
   - name: "Python"
-    weight: 2
+    weight: 4
   - name: "SQL"
-    weight: 3
+    weight: 5
   - name: "Ruby"
     weight: 1
   - name: "Bash"
     weight: 2
   - name: "Batch"
-    weight: 2
+    weight: 3
   - name: "PowerShell"
     weight: 1

--- a/data/skills/languages.yml
+++ b/data/skills/languages.yml
@@ -1,20 +1,20 @@
 weight: 1
 title: "Languages"
 items:
+  - name: "Bash"
+    weight: 2
   - name: "C#"
     weight: 9
   - name: "C++"
     weight: 6
-  - name: "TypeScript"
-    weight: 8
   - name: "Python"
     weight: 4
   - name: "SQL"
     weight: 5
   - name: "Ruby"
     weight: 1
-  - name: "Bash"
-    weight: 2
+  - name: "TypeScript"
+    weight: 8
   - name: "Batch"
     weight: 3
   - name: "PowerShell"

--- a/data/skills/languages.yml
+++ b/data/skills/languages.yml
@@ -6,16 +6,20 @@ items:
   - name: "C#"
     weight: 9
   - name: "C++"
-    weight: 6
+    weight: 7
   - name: "Python"
-    weight: 4
-  - name: "SQL"
     weight: 5
+  - name: "SQL"
+    weight: 6
   - name: "Ruby"
-    weight: 1
+    weight: 3
   - name: "TypeScript"
     weight: 8
   - name: "Batch"
-    weight: 3
+    weight: 4
   - name: "PowerShell"
+    weight: 2
+  - name: "PHP"
+    weight: 1
+  - name: "LabVIEW"
     weight: 1

--- a/data/skills/languages.yml
+++ b/data/skills/languages.yml
@@ -1,0 +1,12 @@
+weight: 1
+title: "Languages"
+items:
+  - name: "C#"
+  - name: "C++"
+  - name: "TypeScript"
+  - name: "Python"
+  - name: "SQL"
+  - name: "Ruby"
+  - name: "Bash"
+  - name: "Batch"
+  - name: "PowerShell"

--- a/data/skills/languages.yml
+++ b/data/skills/languages.yml
@@ -23,3 +23,5 @@ items:
     weight: 1
   - name: "LabVIEW"
     weight: 1
+  - name: "HTML/CSS"
+    weight: 1

--- a/data/skills/leadership.yml
+++ b/data/skills/leadership.yml
@@ -1,17 +1,17 @@
 weight: 4
 title: "Leadership"
 items:
+  - name: "Recruiting"
+    weight: 2
   - name: "Mentorship"
     weight: 9
   - name: "Teaching"
     weight: 4
-  - name: "Recruiting"
-    weight: 2
   - name: "Interviews"
     weight: 6
-  - name: "Scrum champion"
-    weight: 4
   - name: "Presenting"
     weight: 1
+  - name: "Scrum champion"
+    weight: 4
   - name: "Planning"
     weight: 3

--- a/data/skills/leadership.yml
+++ b/data/skills/leadership.yml
@@ -1,0 +1,17 @@
+weight: 4
+title: "Leadership"
+items:
+  - name: "Mentorship"
+    weight: 9
+  - name: "Teaching"
+    weight: 4
+  - name: "Recruiting"
+    weight: 2
+  - name: "Interviews"
+    weight: 6
+  - name: "Scrum champion"
+    weight: 4
+  - name: "Presenting"
+    weight: 1
+  - name: "Planning"
+    weight: 3

--- a/data/skills/platforms.yml
+++ b/data/skills/platforms.yml
@@ -1,10 +1,8 @@
-weight: 2
+weight: 3
 title: "Platforms"
 items:
   - name: ".NET"
     weight: 9
-  - name: "docker"
-    weight: 4
   - name: "AWS"
     weight: 7
   - name: "Azure"
@@ -15,3 +13,7 @@ items:
     weight: 1
   - name: "Windows"
     weight: 2
+  - name: "Linode"
+    weight: 1
+  - name: "Arduino"
+    weight: 6

--- a/data/skills/platforms.yml
+++ b/data/skills/platforms.yml
@@ -17,3 +17,5 @@ items:
     weight: 1
   - name: "Arduino"
     weight: 6
+  - name: "GitHub Actions"
+    weight: 5

--- a/data/skills/platforms.yml
+++ b/data/skills/platforms.yml
@@ -5,17 +5,17 @@ items:
     weight: 9
   - name: "AWS"
     weight: 7
-  - name: "Azure"
-    weight: 5
-  - name: "Node.js"
-    weight: 7
   - name: "Linux"
     weight: 1
+  - name: "Azure"
+    weight: 5
   - name: "Windows"
     weight: 2
-  - name: "Linode"
-    weight: 1
+  - name: "Node.js"
+    weight: 7
   - name: "Arduino"
     weight: 6
+  - name: "Linode"
+    weight: 1
   - name: "GitHub Actions"
     weight: 5

--- a/data/skills/technologies.yml
+++ b/data/skills/technologies.yml
@@ -6,12 +6,14 @@ items:
   - name: "GraphQL"
     weight: 9
   - name: "OpenAPI"
-    weight: 4
+    weight: 1
   - name: "REST APIs"
-    weight: 7
+    weight: 5
   - name: "PostgreSQL"
     weight: 6
   - name: "No-SQL DB"
-    weight: 3
-
-
+    weight: 2
+  - name: "git"
+    weight: 4
+  - name: "CI/CD"
+    weight: 7

--- a/data/skills/technologies.yml
+++ b/data/skills/technologies.yml
@@ -1,0 +1,17 @@
+weight: 2
+title: "Technologies"
+items:
+  - name: "docker"
+    weight: 4
+  - name: "GraphQL"
+    weight: 9
+  - name: "OpenAPI"
+    weight: 4
+  - name: "REST APIs"
+    weight: 7
+  - name: "PostgreSQL"
+    weight: 6
+  - name: "No-SQL DB"
+    weight: 3
+
+

--- a/themes/hugo-lodi-theme/layouts/index.html
+++ b/themes/hugo-lodi-theme/layouts/index.html
@@ -21,6 +21,10 @@
             {{ partial "projects.html" . }}
             {{ end }}
 
+            {{ if .Site.Params.skills.enable }}
+            {{ partial "skills.html" . }}
+            {{ end }}
+
             {{ if .Site.Params.footer.enable }}
             {{ partial "footer.html" . }}
             {{ end }}

--- a/themes/hugo-lodi-theme/layouts/index.html
+++ b/themes/hugo-lodi-theme/layouts/index.html
@@ -3,7 +3,7 @@
     <head>
         {{ partial "head.html" . }}
     </head>
-    <body>
+    <body onload="ShuffleClouds()">
         <div>
             {{ if .Site.Params.nav.enable }}
             {{ partial "nav.html" . }}

--- a/themes/hugo-lodi-theme/layouts/partials/nav.html
+++ b/themes/hugo-lodi-theme/layouts/partials/nav.html
@@ -12,6 +12,10 @@
         {{ if .Site.Params.projects.enable }}
         <a href="#" class="main-navigation-link" data-scroll-goto="2">{{ .Site.Params.projects.title }}</a>
         {{ end }}
+
+        {{ if .Site.Params.skills.enable }}
+        <a href="#" class="main-navigation-link" data-scroll-goto="3">{{ .Site.Params.skills.title }}</a>
+        {{ end }}
         
     </div>
 </nav>

--- a/themes/hugo-lodi-theme/layouts/partials/scripts.html
+++ b/themes/hugo-lodi-theme/layouts/partials/scripts.html
@@ -16,4 +16,29 @@
             easing: 'ease-in-out'
         });
     });
+
+    // Returns an array of [0, 1, ..., length], shuffled
+    function RandomRange(length) {
+        var arr = new Array(length);
+        for (let i = 0; i < length; ++i) {
+            arr[i] = i;
+        }
+        return arr.sort(function(a, b){return 0.5 - Math.random()});
+    }
+
+    // Shuffle the word clouds
+    function ShuffleClouds() {
+        var clouds = document.getElementsByClassName("cloud");
+        for (let i = 0; i < clouds.length; ++i) {
+            var numChildren = clouds[i].children.length;
+            var listItems = new Array(numChildren);
+            var indices = RandomRange(numChildren);
+
+            for (let j = 0; j < numChildren; ++j) {
+                listItems[j] = clouds[i].children[indices[j]].outerHTML;
+            }
+
+            clouds[i].innerHTML = listItems.join('\n');
+        }
+    }
 </script>

--- a/themes/hugo-lodi-theme/layouts/partials/skills.html
+++ b/themes/hugo-lodi-theme/layouts/partials/skills.html
@@ -1,0 +1,20 @@
+<section data-scroll-index="3">
+    <div class="skills">
+        <div class="header">
+            <h1 class="title">{{ .Site.Params.skills.Title }}</h1>
+            <h2 class="subtitle">{{ .Site.Params.skills.Subtitle }}</h2>
+        </div>
+        <div class="skills-wrapper">
+            {{ range $element := sort .Site.Data.skills "weight" }}
+            <div class="skills-item">
+                <h4>{{ $element.title }}</h4>
+                <ul>
+                    {{ range $item := $element.items }}
+                    <li>{{ $item.name }}</li>
+                    {{ end }}
+                </ul>
+            </div>
+            {{ end }}
+        </div>
+    </div>
+</section>

--- a/themes/hugo-lodi-theme/layouts/partials/skills.html
+++ b/themes/hugo-lodi-theme/layouts/partials/skills.html
@@ -8,9 +8,9 @@
             {{ range $element := sort .Site.Data.skills "weight" }}
             <div class="skills-item">
                 <h4>{{ $element.title }}</h4>
-                <ul>
+                <ul class="cloud">
                     {{ range $item := $element.items }}
-                    <li>{{ $item.name }}</li>
+                    <li data-weight="{{ $item.weight }}">{{ $item.name }}</li>
                     {{ end }}
                 </ul>
             </div>

--- a/themes/hugo-lodi-theme/static/css/final.css
+++ b/themes/hugo-lodi-theme/static/css/final.css
@@ -145,6 +145,7 @@ section {
 }
 
 .specialties,
+.skills,
 .projects {
   max-width: 1000px;
   display: -webkit-box;
@@ -235,15 +236,18 @@ section {
   line-height: 0.4em;
 }
 
+.skills-item,
 .specialties-item {
   max-width: 450px;
   padding-top: 20px;
 }
 
+.skills-item,
 .specialties-item h3 {
   margin-left: 15px;
 }
 
+.skills-wrapper,
 .specialties-wrapper {
   display: -webkit-box;
   display: -ms-flexbox;
@@ -306,6 +310,7 @@ section {
   margin-top: 45px;
 }
 
+.skills-item h4,
 .project-item h4 {
   font-size: 26px;
   font-weight: 300;

--- a/themes/hugo-lodi-theme/static/css/final.css
+++ b/themes/hugo-lodi-theme/static/css/final.css
@@ -597,3 +597,34 @@ section {
   transition: 0.2s ease-in-out;
   border-bottom: 3px solid #006d00;
 }
+
+ul.cloud {
+  list-style: none;
+  padding-left: 0;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  line-height: 2.5rem;
+}
+
+ul.cloud li[data-weight="1"] { --size: 1; }
+ul.cloud li[data-weight="2"] { --size: 2; }
+ul.cloud li[data-weight="3"] { --size: 3; }
+ul.cloud li[data-weight="4"] { --size: 4; }
+ul.cloud li[data-weight="5"] { --size: 5; }
+ul.cloud li[data-weight="6"] { --size: 6; }
+ul.cloud li[data-weight="7"] { --size: 7; }
+ul.cloud li[data-weight="8"] { --size: 8; }
+ul.cloud li[data-weight="9"] { --size: 9; }
+
+ul.cloud li {
+  --size: 4;
+  font-size: calc(var(--size) * 0.4rem + 0.3rem);
+  color: #006d00;
+  display: block;
+  font-family: Roboto;
+  padding: 0.125rem 0.25rem;
+  text-decoration: none;
+  position: relative;
+}

--- a/themes/hugo-lodi-theme/static/css/final.css
+++ b/themes/hugo-lodi-theme/static/css/final.css
@@ -622,6 +622,7 @@ ul.cloud li {
   --size: 4;
   font-size: calc(var(--size) * 0.3rem + 0.3rem);
   color: #006d00;
+  opacity: calc((15 - (9 - var(--size))) / 15);
   display: block;
   font-family: Roboto;
   padding: 0.125rem 0.25rem;

--- a/themes/hugo-lodi-theme/static/css/final.css
+++ b/themes/hugo-lodi-theme/static/css/final.css
@@ -620,7 +620,7 @@ ul.cloud li[data-weight="9"] { --size: 9; }
 
 ul.cloud li {
   --size: 4;
-  font-size: calc(var(--size) * 0.4rem + 0.3rem);
+  font-size: calc(var(--size) * 0.3rem + 0.3rem);
   color: #006d00;
   display: block;
   font-family: Roboto;


### PR DESCRIPTION
This PR adds a "Skills" section to the website with various configurable word clouds. The sizes in the cloud (and thus color saturation) are set manually, but the ordering is randomized on each page load.

The word clouds were created following this tutorial: https://dev.to/alvaromontoro/create-a-tag-cloud-with-html-and-css-1e90