### PR TITLE
Update actions/checkout action to v3 for Node16 runtime

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,7 @@ jobs:
   deploy:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: true  # Fetch Hugo themes (true OR recursive)
           fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod


### PR DESCRIPTION
## Description

As per GitHub warning messages, actions must now use node16 runtime. This updates the offending action version.

More info: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

![image](https://user-images.githubusercontent.com/3268813/232264801-789d087e-4141-4205-be44-c84b00551475.png)

## Validation

* Runs as part of this PR