### PR TITLE
More responsive products section on smaller screens

### DIFF
--- a/themes/hugo-lodi-theme/static/css/final.css
+++ b/themes/hugo-lodi-theme/static/css/final.css
@@ -688,7 +688,13 @@ ul.cloud li {
   padding-bottom: 2em;
 }
 
-@media all and (max-width: 400px) {
+@media all and (max-width: 900px) {
+  .products {
+    grid-template-columns: auto auto;
+  }
+}
+
+@media all and (max-width: 550px) {
   .products {
     grid-template-columns: auto;
   }


### PR DESCRIPTION
## Description

Makes products section more responsive with adaptive grid to use two or one column based on screen size. Previously, this was either 3 or 1 column but the measurements weren't quite right on when to switch, so some devices would introduce horizontal scroll.

## Validation

* Tested more thoroughly on Firefox desktop and the build in dev mode mobile view