### PR TITLE
Move skills up page to group non-nav sections

### DIFF
--- a/themes/hugo-lodi-theme/layouts/index.html
+++ b/themes/hugo-lodi-theme/layouts/index.html
@@ -17,16 +17,16 @@
             {{ partial "specialties.html" . }}
             {{ end }}
 
+            {{ if .Site.Params.skills.enable }}
+            {{ partial "skills.html" . }}
+            {{ end }}
+
             {{ if .Site.Params.projects.enable }}
             {{ partial "projects.html" . }}
             {{ end }}
 
             {{ if .Site.Params.products.enable }}
             {{ partial "products.html" (dict "context" . "LIMIT" .Site.Params.products.index_limit "ON_INDEX" true)}}
-            {{ end }}
-
-            {{ if .Site.Params.skills.enable }}
-            {{ partial "skills.html" . }}
             {{ end }}
 
             {{ if .Site.Params.professional_communication.enable }}

--- a/themes/hugo-lodi-theme/layouts/partials/nav.html
+++ b/themes/hugo-lodi-theme/layouts/partials/nav.html
@@ -11,16 +11,16 @@
         <a href="#" class="main-navigation-link" data-scroll-goto="1">{{ .Site.Params.specialties.title }}</a>
         {{ end }}
 
+        {{ if and .Site.Params.skills.enable .Site.Params.skills.on_nav }}
+        <a href="#" class="main-navigation-link" data-scroll-goto="4">{{ .Site.Params.skills.title }}</a>
+        {{ end }}
+
         {{ if and .Site.Params.projects.enable .Site.Params.projects.on_nav }}
         <a href="#" class="main-navigation-link" data-scroll-goto="2">{{ .Site.Params.projects.title }}</a>
         {{ end }}
 
         {{ if and .Site.Params.products.enable .Site.Params.products.on_nav }}
         <a href="#" class="main-navigation-link" data-scroll-goto="3">{{ .Site.Params.products.title }}</a>
-        {{ end }}
-
-        {{ if and .Site.Params.skills.enable .Site.Params.skills.on_nav }}
-        <a href="#" class="main-navigation-link" data-scroll-goto="4">{{ .Site.Params.skills.title }}</a>
         {{ end }}
 
         {{ if and .Site.Params.professional_communication.enable .Site.Params.professional_communication.on_nav }}

--- a/themes/hugo-lodi-theme/layouts/partials/nav.html
+++ b/themes/hugo-lodi-theme/layouts/partials/nav.html
@@ -12,15 +12,15 @@
         {{ end }}
 
         {{ if and .Site.Params.skills.enable .Site.Params.skills.on_nav }}
-        <a href="#" class="main-navigation-link" data-scroll-goto="4">{{ .Site.Params.skills.title }}</a>
+        <a href="#" class="main-navigation-link" data-scroll-goto="2">{{ .Site.Params.skills.title }}</a>
         {{ end }}
 
         {{ if and .Site.Params.projects.enable .Site.Params.projects.on_nav }}
-        <a href="#" class="main-navigation-link" data-scroll-goto="2">{{ .Site.Params.projects.title }}</a>
+        <a href="#" class="main-navigation-link" data-scroll-goto="3">{{ .Site.Params.projects.title }}</a>
         {{ end }}
 
         {{ if and .Site.Params.products.enable .Site.Params.products.on_nav }}
-        <a href="#" class="main-navigation-link" data-scroll-goto="3">{{ .Site.Params.products.title }}</a>
+        <a href="#" class="main-navigation-link" data-scroll-goto="4">{{ .Site.Params.products.title }}</a>
         {{ end }}
 
         {{ if and .Site.Params.professional_communication.enable .Site.Params.professional_communication.on_nav }}

--- a/themes/hugo-lodi-theme/layouts/partials/products.html
+++ b/themes/hugo-lodi-theme/layouts/partials/products.html
@@ -1,4 +1,4 @@
-<section data-scroll-index="3">
+<section data-scroll-index="4">
     <div class="products-page">
         <div class="header">
             <h1 class="title">{{ .context.Site.Params.products.Title }}</h1>

--- a/themes/hugo-lodi-theme/layouts/partials/projects.html
+++ b/themes/hugo-lodi-theme/layouts/partials/projects.html
@@ -1,4 +1,4 @@
-<section data-scroll-index="2">
+<section data-scroll-index="3">
     <div class="projects">
         <div class="header">
             <h1 class="title">{{ .Site.Params.projects.Title }}</h1>

--- a/themes/hugo-lodi-theme/layouts/partials/skills.html
+++ b/themes/hugo-lodi-theme/layouts/partials/skills.html
@@ -1,4 +1,4 @@
-<section data-scroll-index="4">
+<section data-scroll-index="2">
     <div class="skills">
         <div class="header">
             <h1 class="title">{{ .Site.Params.skills.Title }}</h1>


### PR DESCRIPTION
## Description

To follow #28 as a temporary fix to the nav bar, I'm moving skills up the screen to be near the other sections that are not listed on the nav bar. This allows the sections with a jump button on the nav bar to be further down the screen and those without to be grouped at the to for visibility all around.

## Validation

Looks good in desktop Firefox and dev mode mobile view