### PR TITLE
Add UWB Hacks 2023 talk

### DIFF
--- a/data/professional_communication.yml
+++ b/data/professional_communication.yml
@@ -1,3 +1,10 @@
+- date: May 2023
+  type: talk
+  title: Lessons from Building Software at the Pace of Science
+  venue: UWB Hacks 2023 (University of Washington Bothell)
+  links:
+    - display: UWB Hacks 2023
+      url: https://uwb-acm.github.io/uwb-hacks23/
 - date: December 2020
   type: talk
   title: "Integrated Data Framework"


### PR DESCRIPTION
## Description

Adds a talk entry from UWB Hacks 2023.

## Validation

Loads in localhost `hugo server` on firefox desktop